### PR TITLE
Catch OSError when we attempt to run which

### DIFF
--- a/sandboxlib/utils.py
+++ b/sandboxlib/utils.py
@@ -41,7 +41,7 @@ def find_program(program_name):
         try:
             argv = ['which', program_name]
             program_path = subprocess.check_output(argv).strip()
-        except subprocess.CalledProcessError as e:
+        except (subprocess.CalledProcessError, OSError) as e:
             logging.debug("Error searching for %s: %s", program_name, e)
             program_path = None
 


### PR DESCRIPTION
Hi :)

Some distributions define which as an alias,
for example in NixOS which is defined as `type -P',
since subprocess isn't running a shell the which cmd is not found
and an OSError is raised, it's probably reasonable to catch this,
since if we can't find which we can't find linux-user-chroot and
should fallback to chroot. We could run a shell, but it's probably
not worth the security hazard.

I've not been able to run the tests for this, they fail since I do not have linux-user-chroot installed,
they fail without this patch also though.

Hope this helps,
Richard Ipsum
