### PR TITLE
sandboxlib: Allow `None` stdout/stderr to retain forwarding

### DIFF
--- a/sandboxlib/__init__.py
+++ b/sandboxlib/__init__.py
@@ -230,48 +230,33 @@ def _run_command(argv, stdout, stderr, cwd=None, env=None):
 
     This function blocks until the subprocess has terminated.
 
-    Unlike the subprocess.Popen() function, if stdout or stderr are None then
-    output is discarded.
-
     It then returns a tuple of (exit code, stdout output, stderr output).
     If stdout was not equal to subprocess.PIPE, stdout will be None. Same for
     stderr.
 
     '''
-    if stdout is None or stderr is None:
-        dev_null = open(os.devnull, 'w')
-        stdout = stdout or dev_null
-        stderr = stderr or dev_null
-    else:
-        dev_null = None
-
     log = logging.getLogger('sandboxlib')
     log.debug('Running: %s', argv_to_string(argv))
 
-    try:
-        process = subprocess.Popen(
-            argv,
-            # The default is to share file descriptors from the parent process
-            # to the subprocess, which is rarely good for sandboxing.
-            close_fds=True,
-            cwd=cwd,
-            env=env,
-            stdout=stdout,
-            stderr=stderr,
-        )
+    process = subprocess.Popen(
+        argv,
+        # The default is to share file descriptors from the parent process
+        # to the subprocess, which is rarely good for sandboxing.
+        close_fds=True,
+        cwd=cwd,
+        env=env,
+        stdout=stdout,
+        stderr=stderr,
+    )
 
-        # The 'out' variable will be None unless subprocess.PIPE was passed as
-        # 'stdout' to subprocess.Popen(). Same for 'err' and 'stderr'. If
-        # subprocess.PIPE wasn't passed for either it'd be safe to use .wait()
-        # instead of .communicate(), but if they were then we must use
-        # .communicate() to avoid blocking the subprocess if one of the pipes
-        # becomes full. It's safe to use .communicate() in all cases.
+    # The 'out' variable will be None unless subprocess.PIPE was passed as
+    # 'stdout' to subprocess.Popen(). Same for 'err' and 'stderr'. If
+    # subprocess.PIPE wasn't passed for either it'd be safe to use .wait()
+    # instead of .communicate(), but if they were then we must use
+    # .communicate() to avoid blocking the subprocess if one of the pipes
+    # becomes full. It's safe to use .communicate() in all cases.
 
-        out, err = process.communicate()
-    finally:
-        if dev_null is not None:
-            dev_null.close()
-
+    out, err = process.communicate()
     return process.returncode, out, err
 
 


### PR DESCRIPTION
I couldn't work out a way to make sandboxlib let me keep my stdout/stderr otherwise.
I'm not a fan of changing the default behaviour of this, especially without a documented way to preserve it.
