### PR TITLE
Mount more flexibility

### DIFF
--- a/sandboxlib/chroot.py
+++ b/sandboxlib/chroot.py
@@ -101,8 +101,18 @@ def mount(source, path, mount_type, mount_options):
     # little sad. It's possible to call the libc's mount() function
     # directly from Python using the 'ctypes' library, and perhaps we
     # should do that instead.
-    argv = [
-        'mount', '-t', mount_type, '-o', mount_options, source, path]
+    def is_none(value):
+        return value in (None, 'none', '')
+
+    argv = ['mount']
+    if not is_none(mount_type):
+        argv.extend(('-t', mount_type))
+    if not is_none(mount_options):
+        argv.extend(('-o', mount_options))
+    if not is_none(source):
+        argv.append(source)
+    argv.append(path)
+
     exit, out, err = sandboxlib._run_command(
         argv, stdout=sandboxlib.CAPTURE, stderr=sandboxlib.CAPTURE)
 

--- a/sandboxlib/chroot.py
+++ b/sandboxlib/chroot.py
@@ -147,7 +147,8 @@ def mount_all(rootfs_path, mount_info_list):
                 os.makedirs(path)
 
             mount(source, path, mount_type, mount_options)
-            mounted.append(path)
+            if not mount_options or 'remount' not in mount_options:
+                mounted.append(path)
 
         yield
     finally:

--- a/sandboxlib/linux_user_chroot.py
+++ b/sandboxlib/linux_user_chroot.py
@@ -100,6 +100,14 @@ def args_for_mount(mount_source, mount_target, mount_type, mount_options,
                 mount_type)
         else:
             args = ['--mount-bind', mount_source, mount_target]
+    elif mount_options and all(opt in mount_options.split(",")
+                               for opt in ("remount", "ro")):
+        if not is_none(mount_type):
+            raise AssertionError(
+                "Type cannot be specified for 'remount,ro' mounts. Got '%s'" %
+                mount_type)
+        else:
+            args = ['--mount-readonly', mount_target]
     else:
         raise AssertionError(
             "Unsupported mount type '%s' for linux-user-chroot backend." %


### PR DESCRIPTION
I ported a program of mine that previously only used linux-user-chroot to use sandboxlib,
but to get the features I needed I had to make a few changes.

I made use of binding things in, and specifically making those binds read-only, so I needed a way to make sandboxlib make it read-only, so I made it look for the mount options that would do that and translate it to `--mount-readonly`.
